### PR TITLE
docs: add section about log level on CLI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,8 @@ docker exec -it phenix phenix <command>
 
 ## 📚 Documentation
 
-*   [**Configuration**](configuration.md): Learn about Topologies, Scenarios, and Experiments.
-*   [**Settings**](settings.md): Configure the phēnix daemon (logging, storage, UI).
-*   [**Experiments**](experiments.md): Manage the lifecycle of your experiments.
-*   [**Apps**](apps.md): Extend functionality with Apps.
+* [**Configuration**](configuration.md): Learn about Topologies, Scenarios, and Experiments.
+* [**Settings**](settings.md): Configure the phēnix daemon (logging, storage, UI).
+* [**Experiments**](experiments.md): Manage the lifecycle of your experiments.
+* [**Apps**](apps.md): Extend functionality with Apps.
+* [**Logging**](logging.md): Learn about the logging facilities in phēnix and how to increase verbosity

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -45,6 +45,56 @@ graph TD
     Core -->|ProcessStderrLogs| Plog
 ```
 
+## CLI Verbosity (`--log.level`)
+
+You can temporarily increase or decrease log verbosity for any command by using the global `--log.level` flag.
+
+```bash
+phenix <command> --log.level=<level>
+```
+
+This is useful when troubleshooting because it only affects that command invocation.
+
+### Available Levels
+
+phēnix supports the following log levels for `--log.level`:
+
+* `debug`: Most verbose output for troubleshooting.
+* `info`: Default level. Normal operational messages.
+* `warn`: Warnings and errors.
+* `error`: Errors only.
+* `none`: Suppress all standard log output.
+
+!!! note
+    Level names are case-insensitive (for example, `DEBUG` and `debug` are equivalent).
+
+### Examples
+
+Use higher verbosity to inspect behavior while running a command:
+
+```bash
+# Run the UI with debug logging for this invocation
+phenix ui --log.level=debug
+
+# Show only warnings and errors while listing experiments
+phenix exp list --log.level=warn
+
+# Keep command output quiet unless an error occurs
+phenix config get --log.level=error Role/vm-admin
+```
+
+To change the default level for all future commands, use settings:
+
+```bash
+phenix settings set log.level debug
+```
+
+To revert and use the configured default again for subsequent commands:
+
+```bash
+phenix settings unset log.level
+```
+
 ## The App Contract
 
 All applications (Go or Python) running under phēnix must adhere to the following contract to ensure their logs are correctly parsed and displayed in the UI:


### PR DESCRIPTION
# docs: add section about log level on CLI

## Description
Add some documentation about how to configure logging levels in phenix from the CLI, to help with troubleshooting. 

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-docs/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A
