### PR TITLE
docs: update mgmt_tap docs to match merged PR #118

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -512,11 +512,9 @@ spec:
 
 ### mgmt_tap App
 The `mgmt_tap` application creates tap interfaces on the management network of an experiment, enabling file transfer and remote access to virtual machines within the experiment. The `mgmt_tap`:
-- Creates taps specifically on the MGMT VLAN
-- Creates taps on all compute hosts in the experiment
-- Automatically assigns IPs with configurable subnet
-- Optionally applied IP namespace isolation
-- Removes taps and namespaces during cleanup phase
+- Creates taps on the configured VLAN (defaults to `MGMT`) on all compute hosts in the experiment
+- Automatically assigns sequential IPs from a configurable subnet
+- Removes taps during cleanup phase
 
 The following is an example of how the default `mgmt_tap` app can be configured via a `Scenario` configuration.
 
@@ -526,27 +524,20 @@ spec:
     - name: mgmt_tap
 ```
 
-This creates:
-- Tap interfaces on all hosts with IPs `172.16.111.1/16`, `172.16.111.2/16`, etc.
-- No network namespace isolation
-- Basic tap creation on MGMT VLAN
+This creates tap interfaces on all hosts with IPs `172.16.0.1/16`, `172.16.0.2/16`, etc. on the `MGMT` VLAN.
 
-
-The following is an example of how the `mgmt_tap` app can be configured via a `Scenario` configuration with optional settings `subnet` and `namespace`.
+The following is an example of how the `mgmt_tap` app can be configured via a `Scenario` configuration with optional settings `subnet` and `vlan`.
 
 ```yaml title="mgmt_tap app optional example"
 spec:
   apps:
     - name: mgmt_tap
       metadata:
-        subnet: 172.16.0.0/16
-        namespace: true
+        subnet: 10.0.0.0/24
+        vlan: INTERNAL
 ```
 
-This creates:
-- Tap interfaces with IPs `172.16.0.1/16`, `172.16.0.2/16`, etc.
-- Each tap in its own network namespace (`<exp_name>_net`)
-- Full namespace isolation for IP address conflicts
+This creates tap interfaces with IPs `10.0.0.1/24`, `10.0.0.2/24`, etc. on the `INTERNAL` VLAN.
 
 ## User Apps
 


### PR DESCRIPTION
Removes non-existent namespace metadata option, fixes default IPs, and corrects the optional example to use subnet and vlan parameters.

# Pull Request Title

## Description
Please include a summary of the changes and the related issue. 

## Related Issue
If applicable, please link to the issue here (e.g., #123).

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-docs/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
