### PR TITLE
docs: document tap app stage option and fix delay field name

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -462,6 +462,13 @@ default netns.
     configurations. If you experience problems with external access, it may be
     due to a more restrictive iptables configuration than we've tested with.
 
+By default, the host taps are created during the experiment's **post-start**
+stage. The optional `stage` metadata option can be used to instead create the
+taps during the **pre-start** stage, which is useful when other apps or VMs need
+the taps to already exist when the experiment starts. Valid values are
+`pre-start` and `post-start`; when unset, it defaults to `post-start` to
+preserve backwards compatibility.
+
 The following is an example of how the `tap` app can be configured via a
 `Scenario` configuration, showing all the possible options.
 
@@ -474,6 +481,10 @@ spec:
   apps:
     - name: tap
       metadata:
+        # the experiment lifecycle stage to create the taps in -- valid values
+        # are 'pre-start' and 'post-start' (will default to 'post-start' if not
+        # provided)
+        stage: post-start
         taps:
             # the bridge to add the tap to (will default to 'phenix' if not provided)
           - bridge: phenix

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,7 +111,7 @@ Optional values for a node in the topology configuration can include:
 - file injections (and main disk inject partition)
 - labels, which are typically used by phēnix apps
 - routing ruleset(s)
-- delay triggered by `user`, `time`, or `c2` (command and control)
+- delay triggered by `user`, `timer`, or `c2` (command and control)
 
 !!! warning
     If not specified, the default disk partition to inject files into is `1`.
@@ -128,7 +128,7 @@ three options available to set, but on only one option can be set:
    start either through the phēnix UI or command line (the latter can be by
    phēnix or minimega commands).
 
-1. `time` is a string that is set as a delay in minutes; e.g., `5m`.
+1. `timer` is a string that is set as a delay in minutes; e.g., `5m`.
 
 1. `c2` requires minimega command and control. Note in the example below that
    the hostname `AD1` will be delayed starting until the VM `host-00` has
@@ -227,7 +227,7 @@ spec:
       snapshot: true
       do_not_boot: false
     delay:
-      time: 5m
+      timer: 5m
     hardware:
       os_type: linux
       drives:


### PR DESCRIPTION
## Description
Two documentation updates:

1. **tap app `stage` option** (`docs/apps.md`) — documents the new `stage`
   metadata option for the `tap` app, which controls which experiment lifecycle
   stage the host taps are created in (`pre-start` or `post-start`, defaulting to
   `post-start`). This documents the feature added in upstream code PR
   [sandialabs/sceptre-phenix#329](https://github.com/sandialabs/sceptre-phenix/pull/329).

2. **delay start field name fix** (`docs/configuration.md`) — corrects the
   delay-start option name from `time` to `timer`, matching the actual field
   name (`yaml:"timer"`) in the topology schema's `Delay` struct. Fixed in the
   prose description and the topology YAML example.

## Related Issue
N/A — item 1 documents sandialabs/sceptre-phenix#329.

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-docs/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
Documentation-only change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
