### PR TITLE
fix(ci): stop fork PR merges from breaking the docs deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,14 +7,22 @@ on:
       - dev
   # Allow manual triggering for feature branch previews
   workflow_dispatch:
-  # Trigger cleanup when a PR is closed
-  pull_request:
+  # Trigger cleanup when a PR is closed. Uses pull_request_target (not
+  # pull_request) so the GITHUB_TOKEN keeps write access even when the PR
+  # came from a fork -- pull_request always forces a read-only token for
+  # fork PRs, which is not enough to push the gh-pages deletion commit.
+  # Safe here because this job never checks out or executes the PR's head
+  # ref/code; it only computes a branch-derived version name.
+  pull_request_target:
     types:
       - closed
 
-# Cancel in-progress builds if a new commit is pushed to the same branch
+# Cancel in-progress builds if a new commit is pushed to the same branch.
+# Keyed by event_name as well as ref: a merged fork PR fires both a `push`
+# to main and a `pull_request`/`pull_request_target` `closed` event that
+# both resolve to refs/heads/main, and they must not cancel each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -45,13 +53,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       # Automatic deployment for main -> latest
+      # Restricted to the `push` event: a closed pull_request_target for a
+      # merged PR also resolves github.ref to refs/heads/main (the merge
+      # ref no longer exists once the PR is closed), so without this guard
+      # this step would also fire on PR-close, racing the real push run.
       - name: Deploy documentation from main branch
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: mike deploy --push --update-aliases latest
 
       # Automatic deployment for dev -> dev
       - name: Deploy documentation from dev branch
-        if: github.ref == 'refs/heads/dev'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         run: mike deploy --push dev
 
       # Manual deployment for feature branches -> feat-branch-name
@@ -66,7 +78,7 @@ jobs:
 
       # Automatic cleanup of feature branch deployments
       - name: Delete documentation version for closed PR
-        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
         run: |
           # Sanitize the branch name using the same logic as deployment
           VERSION=$(echo $GITHUB_HEAD_REF | sed 's/[^a-zA-Z0-9]/-/g')


### PR DESCRIPTION
## Description
Fixes the "Deploy Documentation" workflow failing with a 403 whenever a PR from a **fork** is merged (e.g. https://github.com/sandialabs/sceptre-phenix-docs/actions/runs/29935711606/job/88976614649).

Root cause: merging a fork PR fires two workflow runs — a `push` to `main` (normal write token) and a `pull_request` `closed` event sourced from the fork, which GitHub *always* forces to a read-only `GITHUB_TOKEN`, regardless of the `permissions:` block in the workflow. Because a closed PR's merge ref no longer exists, `github.ref` falls back to `refs/heads/main` for that `pull_request` run too, so it lands in the same `concurrency` group as the real `push` run. Whichever run starts second cancels the other — sometimes that's the good `push` run, which gets killed mid-deploy by the fork-triggered run, which then itself fails pushing to `gh-pages` with `403 Permission denied`.

Changes:
- Trigger the PR-close cleanup via `pull_request_target` instead of `pull_request`, so it keeps a write-scoped token even for fork PRs. Safe here since this job never checks out or executes the PR's fork code — it only derives a version name from the branch.
- Scope the "Deploy documentation from main/dev branch" steps to `github.event_name == 'push'` so they can no longer accidentally fire on a PR-close event.
- Key the `concurrency` group on `event_name` as well as `ref` so the deploy run and the cleanup run never cancel each other.

## Related Issue
N/A — found while investigating a failed deploy run after merging a fork PR.

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-docs/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
Not yet verified against a live fork-PR merge — the failure mode only reproduces on a real merge from a forked repository, which needs a real PR round-trip against `sandialabs/sceptre-phenix-docs` to confirm.
