### PR TITLE
docs(schema): refresh phenix schemas

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -11,23 +11,21 @@ here](#node-schemas).
 ```yaml
 Topology:
   type: object
-  title: Demo Topology
   anyOf:
   - required:
-	- nodes
+    - nodes
   - required:
-	- includeTopologies
+    - includeTopologies
   properties:
     includeTopologies:
       type: array
       items:
-      type: string
+        type: string
       example:
       - /phenix/topologies/enterprise/phenix-configs/topology.yml
       - store-topo
     nodes:
       type: array
-      title: Nodes
       items:
         oneOf:
         - $ref: '#/components/schemas/minimega_node'
@@ -43,51 +41,51 @@ Scenario:
   required:
   - apps
   properties:
-	apps:
-	  type: array
-	  nullable: true
-	  items:
-		type: object
-		required:
-		- name
-		properties:
-		  name:
-			type: string
-			example: example-app
-		  assetDir:
-			type: string
-			example: /phenix/topologies/example-topo/assets
-		  metadata:
-			type: object
-			nullable: true
-			additionalProperties: true
-			example:
-			  setting0: true
-			  setting1: 42
-			  setting2: universe key
-		  disabled:
-			type: boolean
-			default: false
-			example: false
-			nullable: true	  
-		  hosts:
-			type: array
-			items:
-			  type: object
-			  required:
-			  - hostname
-			  properties:
-				hostname:
-				  type: string
-				  example: example-host
-				metadata:
-				  type: object
-				  nullable: true
-				  additionalProperties: true
-				  example:
-					setting0: true
-					setting1: 42
-					setting2: universe key
+    apps:
+      type: array
+      nullable: true
+      items:
+        type: object
+        required:
+        - name
+        properties:
+          name:
+            type: string
+            example: example-app
+          assetDir:
+            type: string
+            example: /phenix/topologies/example-topo/assets
+          metadata:
+            type: object
+            nullable: true
+            additionalProperties: true
+            example:
+              setting0: true
+              setting1: 42
+              setting2: universe key
+          disabled:
+            type: boolean
+            default: false
+            example: false
+            nullable: true
+          hosts:
+            type: array
+            items:
+              type: object
+              required:
+              - hostname
+              properties:
+                hostname:
+                  type: string
+                  example: example-host
+                metadata:
+                  type: object
+                  nullable: true
+                  additionalProperties: true
+                  example:
+                    setting0: true
+                    setting1: 42
+                    setting2: universe key
 ```
 
 ## Experiment Schema
@@ -98,39 +96,39 @@ Experiment:
   required:
   - topology
   properties:
-	topology:
-	  $ref: "#/components/schemas/Topology"
-	scenario:
-	  $ref: "#/components/schemas/Scenario"
-	baseDir:
-	  type: string
-	  example: /phenix/topologies/example-topo
-	experimentName:
-	  type: string
-	  example: example-exp
-	  readOnly: true
-	vlans:
-	  type: object
-	  nullable: true
-	  properties:
-		aliases:
-		  type: object
-		  nullable: true
-		  additionalProperties:
-			type: integer
-		  example:
-			MGMT: 200
-		min:
-		  type: integer
-		max:
-		  type: integer
-	schedule:
-	  type: object
-	  nullable: true
-	  additionalProperties:
-		type: string
-	  example:
-		ADServer: compute1
+    topology:
+      $ref: "#/components/schemas/Topology"
+    scenario:
+      $ref: "#/components/schemas/Scenario"
+    baseDir:
+      type: string
+      example: /phenix/topologies/example-topo
+    experimentName:
+      type: string
+      example: example-exp
+      readOnly: true
+    vlans:
+      type: object
+      nullable: true
+      properties:
+        aliases:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: integer
+          example:
+            MGMT: 200
+        min:
+          type: integer
+        max:
+          type: integer
+    schedule:
+      type: object
+      nullable: true
+      additionalProperties:
+        type: string
+      example:
+        ADServer: compute1
 ```
 
 ## Image Schema
@@ -145,62 +143,62 @@ Image:
   - size
   - variant
   properties:
-	compress:
-	  type: boolean
-	  default: false
-	  example: false
-	deb_append:
-	  type: string
-	  example: --components=main,restricted
-	format:
-	  type: string
-	  example: qcow2
-	mirror:
-	  type: string
-	  example: http://us.archive.ubuntu.com/ubuntu/
-	overlays:
-	  type: array
-	  nullable: true
-	  items:
-		type: string
-	  example:
-	  - /phenix/vmdb/overlays/example-overlay
-	packages:
-	  type: array
-	  nullable: true
-	  items:
-		type: string
-	  example:
-	  - isc-dhcp-client
-	  - openssh-server
-	ramdisk:
-	  type: boolean
-	  default: false
-	  example: false
-	release:
-	  type: string
-	  example: focal
-	script_order:
-	  type: array
-	  nullable: true
-	  items:
-		type: string
-	  example:
-	  - POSTBUILD_APT_CLEANUP
-	scripts:
-	  type: object
-	  nullable: true
-	  additionalProperties:
-		type: string
-	  example:
-		POSTBUILD_APT_CLEANUP: |
-		  apt clean || apt-get clean || echo "unable to clean apt cache"
-	size:
-	  type: string
-	  example: 10G
-	variant:
-	  type: string
-	  example: minbase
+    compress:
+      type: boolean
+      default: false
+      example: false
+    deb_append:
+      type: string
+      example: --components=main,restricted
+    format:
+      type: string
+      example: qcow2
+    mirror:
+      type: string
+      example: http://us.archive.ubuntu.com/ubuntu/
+    overlays:
+      type: array
+      nullable: true
+      items:
+        type: string
+      example:
+      - /phenix/vmdb/overlays/example-overlay
+    packages:
+      type: array
+      nullable: true
+      items:
+        type: string
+      example:
+      - isc-dhcp-client
+      - openssh-server
+    ramdisk:
+      type: boolean
+      default: false
+      example: false
+    release:
+      type: string
+      example: focal
+    script_order:
+      type: array
+      nullable: true
+      items:
+        type: string
+      example:
+      - POSTBUILD_APT_CLEANUP
+    scripts:
+      type: object
+      nullable: true
+      additionalProperties:
+        type: string
+      example:
+        POSTBUILD_APT_CLEANUP: |
+          apt clean || apt-get clean || echo "unable to clean apt cache"
+    size:
+      type: string
+      example: 10G
+    variant:
+      type: string
+      example: minbase
 ```
 
 ## User Schema
@@ -213,23 +211,23 @@ User:
   - last_name
   - username
   properties:
-	first_name:
-	  type: string
-	  example: John
-	last_name:
-	  type: string
-	  example: Doe
-	password:
-	  type: string
-	  example: '<encrypted password>'
-	  readOnly: true
-	rbac:
-	  allOf:
-	  - $ref: "#/components/schemas/Role"
-	  readOnly: true
-	username:
-	  type: string
-	  example: johndoe@example.com
+    first_name:
+      type: string
+      example: John
+    last_name:
+      type: string
+      example: Doe
+    password:
+      type: string
+      example: '<encrypted password>'
+      readOnly: true
+    rbac:
+      allOf:
+      - $ref: "#/components/schemas/Role"
+      readOnly: true
+    username:
+      type: string
+      example: johndoe@example.com
 ```
 
 ## Role Schema
@@ -241,35 +239,35 @@ Role:
   - policies
   - roleName
   properties:
-	policies:
-	  type: array
-	  items:
-		type: object
-		properties:
-		  resources:
-			type: array
-			items:
-			  type: string
-		  resourceNames:
-			type: array
-			items:
-			  type: string
-		  verbs:
-			type: array
-			items:
-			  type: string
-	  example:
-	  - resources:
-		- experiments
-		- experiments/*
-		resourceNames:
-		- '*'
-		verbs:
-		- list
-		- get
-	roleName:
-	  type: string
-	  example: Example Role
+    policies:
+      type: array
+      items:
+        type: object
+        properties:
+          resources:
+            type: array
+            items:
+              type: string
+          resourceNames:
+            type: array
+            items:
+              type: string
+          verbs:
+            type: array
+            items:
+              type: string
+      example:
+      - resources:
+        - experiments
+        - experiments/*
+        resourceNames:
+        - '*'
+        verbs:
+        - list
+        - get
+    roleName:
+      type: string
+      example: Example Role
 ```
 
 ## Node Schemas
@@ -287,319 +285,319 @@ minimega_node:
   - general
   - hardware
   properties:
-	type:
-	  type: string
-	  default: VirtualMachine
-	  example: VirtualMachine
-	general:
-	  type: object
-	  required:
-	  - hostname
-	  properties:
-		hostname:
-		  type: string
-		  example: ADServer
-		  minLength: 1
-		  maxLength: 63
-		  pattern: '^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'
-		description:
-		  type: string
-		  example: Active Directory Server
-		vm_type:
-		  type: string
-		  enum:
-		  - kvm
-		  - container
-		  - ""
-		  default: kvm
-		  example: kvm
-		snapshot:
-		  type: boolean
-		  default: false
-		  example: false
-		  nullable: true
-		do_not_boot:
-		  type: boolean
-		  default: false
-		  example: false
-		  nullable: true
-	hardware:
-	  type: object
-	  required:
-	  - os_type
-	  - drives
-	  properties:
-		cpu:
-		  type: string
-		  default: Broadwell
-		  example: Broadwell
-		vcpus:
-		  oneOf:
-		  - type: integer
-		  - type: string
-		  default: 1
-		  example: 4
-		memory:
-		  oneOf:
-		  - type: integer
-		  - type: string
-		  default: 1024
-		  example: 8192
-		os_type:
-		  type: string
-		  enum:
-		  - centos
-		  - linux
-		  - minirouter
-		  - rhel
-		  - vyatta
-		  - vyos
-		  - windows
-		  - other
-		  default: linux
-		  example: windows
-		drives:
-		  type: array
-		  minItems: 1
-		  items:
-			type: object
-			required:
-			- image
-			properties:
-			  image:
-				type: string
-				minLength: 1
-				example: ubuntu.qc2
-			  interface:
-				type: string
-				enum:
-				- ahci
-				- ide
-				- scsi
-				- sd
-				- mtd
-				- floppy
-				- pflash
-				- virtio
-				- ""
-				default: ide
-				example: ide
-			  cache_mode:
-				type: string
-				enum:
-				- none
-				- writeback
-				- unsafe
-				- directsync
-				- writethrough
-				- ""
-				default: writeback
-				example: writeback
-			  inject_partition:
-				type: integer
-				default: 1
-				example: 2
-				nullable: true
-	network:
-	  type: object
-	  nullable: true
-	  required:
-	  - interfaces
-	  properties:
-		interfaces:
-		  type: array
-		  nullable: true
-		  items:
-			type: object
-			oneOf:
-			- $ref: '#/components/schemas/static_iface'
-			- $ref: '#/components/schemas/dhcp_iface'
-			- $ref: '#/components/schemas/serial_iface'
-		routes:
-		  type: array
-		  nullable: true
-		  items:
-			type: object
-			required:
-			- destination
-			- next
-			properties:
-			  destination:
-				type: string
-				example: 192.168.0.0/24
-			  next:
-				type: string
-				example: 192.168.1.254
-			  cost:
-				type: integer
-				default: 1
-				example: 1
-				nullable: true
-		ospf:
-		  type: object
-		  nullable: true
-		  required:
-		  - router_id
-		  - areas
-		  properties:
-			router_id:
-			  type: string
-			  example: 0.0.0.1
-			areas:
-			  type: array
-			  items:
-				type: object
-				required:
-				- area_id
-				- area_networks
-				properties:
-				  area_id:
-					type: integer
-					example: 1
-					default: 1
-				  area_networks:
-					type: array
-					items:
-					  type: object
-					  required:
-					  - network
-					  properties:
-						network:
-						  type: string
-						  example: 10.1.25.0/24
-		rulesets:
-		  type: array
-		  nullable: true
-		  items:
-			type: object
-			required:
-			- name
-			- default
-			- rules
-			properties:
-			  name:
-				type: string
-				example: OutToDMZ
-			  description:
-				type: string
-				example: From Corp to the DMZ network
-			  default:
-				type: string
-				enum:
-				- accept
-				- drop
-				- reject
-				example: drop
-			  rules:
-				type: array
-				items:
-				  type: object
-				  required:
-				  - id
-				  - action
-				  - protocol
-				  properties:
-					id:
-					  type: integer
-					  example: 10
-					description:
-					  type: string
-					  example: Allow UDP 10.1.26.80 ==> 10.2.25.0/24:123
-					action:
-					  type: string
-					  enum:
-					  - accept
-					  - drop
-					  - reject
-					  example: accept
-					protocol:
-					  type: string
-					  enum:
-					  - tcp
-					  - udp
-					  - tcp_udp
-					  - icmp
-					  - esp
-					  - ah
-					  - all
-					  default: tcp
-					  example: tcp
-					source:
-					  type: object
-					  nullable: true
-					  required:
-					  - address
-					  properties:
-						address:
-						  type: string
-						  example: 10.1.24.60
-						port:
-						  type: integer
-						  example: 3389
-					destination:
-					  type: object
-					  nullable: true
-					  required:
-					  - address
-					  properties:
-						address:
-						  type: string
-						  example: 10.1.24.60
-						port:
-						  type: integer
-						  example: 3389
-	injections:
-	  type: array
-	  nullable: true
-	  items:
-		type: object
-		required:
-		- src
-		- dst
-		properties:
-		  src:
-			type: string
-			example: foo.xml
-		  dst:
-			type: string
-			example: /etc/phenix/foo.xml
-		  description:
-			type: string
-			example: phenix config file
-		  permissions:
-			type: string
-			example: '0664'
-	delay:
-	  type: object
-	  nullable: true
-	  properties:
-		timer:
-		  type: string
-		  example: 5m
-		user:
-		  type: boolean
-		c2:
-		  type: array
-		  nullable: true
-		  items:
-			type: object
-			properties:
-			  hostname:
-				type: string
-			  useUUID:
-				type: boolean
-	advanced:
-	  type: object
-	  nullable: true
-	  additionalProperties:
-		type: string
-	commands:
-	  type: array
-	  nullable: true
-	  items:
-		type: string
-	  example:
-	  - exec df -h
+    type:
+      type: string
+      default: VirtualMachine
+      example: VirtualMachine
+    general:
+      type: object
+      required:
+      - hostname
+      properties:
+        hostname:
+          type: string
+          minLength: 1
+          maxLength: 63
+          pattern: '^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$'
+          example: ADServer
+        description:
+          type: string
+          example: Active Directory Server
+        vm_type:
+          type: string
+          enum:
+          - kvm
+          - container
+          - ""
+          default: kvm
+          example: kvm
+        snapshot:
+          type: boolean
+          default: false
+          example: false
+          nullable: true
+        do_not_boot:
+          type: boolean
+          default: false
+          example: false
+          nullable: true
+    hardware:
+      type: object
+      required:
+      - os_type
+      - drives
+      properties:
+        cpu:
+          type: string
+          default: Broadwell
+          example: Broadwell
+        vcpus:
+          oneOf:
+          - type: integer
+          - type: string
+          default: 1
+          example: 4
+        memory:
+          oneOf:
+          - type: integer
+          - type: string
+          default: 1024
+          example: 8192
+        os_type:
+          type: string
+          enum:
+          - centos
+          - linux
+          - minirouter
+          - rhel
+          - vyatta
+          - vyos
+          - windows
+          - other
+          default: linux
+          example: windows
+        drives:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required:
+            - image
+            properties:
+              image:
+                type: string
+                minLength: 1
+                example: ubuntu.qc2
+              interface:
+                type: string
+                enum:
+                - ahci
+                - ide
+                - scsi
+                - sd
+                - mtd
+                - floppy
+                - pflash
+                - virtio
+                - ""
+                default: ide
+                example: ide
+              cache_mode:
+                type: string
+                enum:
+                - none
+                - writeback
+                - unsafe
+                - directsync
+                - writethrough
+                - ""
+                default: writeback
+                example: writeback
+              inject_partition:
+                type: integer
+                default: 1
+                example: 2
+                nullable: true
+    network:
+      type: object
+      nullable: true
+      required:
+      - interfaces
+      properties:
+        interfaces:
+          type: array
+          nullable: true
+          items:
+            type: object
+            oneOf:
+            - $ref: '#/components/schemas/static_iface'
+            - $ref: '#/components/schemas/dhcp_iface'
+            - $ref: '#/components/schemas/serial_iface'
+        routes:
+          type: array
+          nullable: true
+          items:
+            type: object
+            required:
+            - destination
+            - next
+            properties:
+              destination:
+                type: string
+                example: 192.168.0.0/24
+              next:
+                type: string
+                example: 192.168.1.254
+              cost:
+                type: integer
+                default: 1
+                example: 1
+                nullable: true
+        ospf:
+          type: object
+          nullable: true
+          required:
+          - router_id
+          - areas
+          properties:
+            router_id:
+              type: string
+              example: 0.0.0.1
+            areas:
+              type: array
+              items:
+                type: object
+                required:
+                - area_id
+                - area_networks
+                properties:
+                  area_id:
+                    type: integer
+                    example: 1
+                    default: 1
+                  area_networks:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - network
+                      properties:
+                        network:
+                          type: string
+                          example: 10.1.25.0/24
+        rulesets:
+          type: array
+          nullable: true
+          items:
+            type: object
+            required:
+            - name
+            - default
+            - rules
+            properties:
+              name:
+                type: string
+                example: OutToDMZ
+              description:
+                type: string
+                example: From Corp to the DMZ network
+              default:
+                type: string
+                enum:
+                - accept
+                - drop
+                - reject
+                example: drop
+              rules:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - id
+                  - action
+                  - protocol
+                  properties:
+                    id:
+                      type: integer
+                      example: 10
+                    description:
+                      type: string
+                      example: Allow UDP 10.1.26.80 ==> 10.2.25.0/24:123
+                    action:
+                      type: string
+                      enum:
+                      - accept
+                      - drop
+                      - reject
+                      example: accept
+                    protocol:
+                      type: string
+                      enum:
+                      - tcp
+                      - udp
+                      - tcp_udp
+                      - icmp
+                      - esp
+                      - ah
+                      - all
+                      default: tcp
+                      example: tcp
+                    source:
+                      type: object
+                      nullable: true
+                      required:
+                      - address
+                      properties:
+                        address:
+                          type: string
+                          example: 10.1.24.60
+                        port:
+                          type: integer
+                          example: 3389
+                    destination:
+                      type: object
+                      nullable: true
+                      required:
+                      - address
+                      properties:
+                        address:
+                          type: string
+                          example: 10.1.24.60
+                        port:
+                          type: integer
+                          example: 3389
+    injections:
+      type: array
+      nullable: true
+      items:
+        type: object
+        required:
+        - src
+        - dst
+        properties:
+          src:
+            type: string
+            example: foo.xml
+          dst:
+            type: string
+            example: /etc/phenix/foo.xml
+          description:
+            type: string
+            example: phenix config file
+          permissions:
+            type: string
+            example: '0664'
+    delay:
+      type: object
+      nullable: true
+      properties:
+        timer:
+          type: string
+          example: 5m
+        user:
+          type: boolean
+        c2:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              hostname:
+                type: string
+              useUUID:
+                type: boolean
+    advanced:
+      type: object
+      nullable: true
+      additionalProperties:
+        type: string
+    commands:
+      type: array
+      nullable: true
+      items:
+        type: string
+      example:
+      - exec df -h
 ```
 
 ### `external_node` Schema
@@ -612,99 +610,99 @@ external_node:
   - type
   - general
   properties:
-	external:
-	  type: boolean
-	type:
-	  type: string
-	  default: HIL
-	  example: HIL
-	general:
-	  type: object
-	  required:
-	  - hostname
-	  properties:
-		hostname:
-		  type: string
-		  example: ADServer
-		description:
-		  type: string
-		  example: Active Directory Server
-		vm_type:
-		  type: string
-		  enum:
-		  - vm
-		  - container
-		  - ""
-		  default: vm
-		  example: vm
-	hardware:
-	  type: object
-	  nullable: true
-	  required:
-	  - os_type
-	  properties:
-		cpu:
-		  type: string
-		  default: Broadwell
-		  example: Broadwell
-		vcpus:
-		  oneOf:
-		  - type: integer
-		  - type: string
-		  default: 1
-		  example: 4
-		memory:
-		  oneOf:
-		  - type: integer
-		  - type: string
-		  default: 1024
-		  example: 8192
-		os_type:
-		  type: string
-		  default: linux
-		  example: windows
-	network:
-	  type: object
-	  nullable: true
-	  required:
-	  - interfaces
-	  properties:
-		interfaces:
-		  type: array
-		  items:
-			type: object
-			required:
-			- name
-			properties:
-			  name:
-				type: string
-				example: eth0
-			  proto:
-				type: string
-				enum:
-				- static
-				- dhcp
-				- manual
-				- ""
-				default: dhcp
-				example: static
-			  address:
-				type: string
-				format: ipv4
-				example: 192.168.1.100
-			  mask:
-				type: integer
-				minimum: 0
-				maximum: 32
-				default: 24
-				example: 24
-			  gateway:
-				type: string
-				format: ipv4
-				example: 192.168.1.1
-			  vlan:
-				type: string
-				example: EXP-1
+    external:
+      type: boolean
+    type:
+      type: string
+      default: HIL
+      example: HIL
+    general:
+      type: object
+      required:
+      - hostname
+      properties:
+        hostname:
+          type: string
+          example: ADServer
+        description:
+          type: string
+          example: Active Directory Server
+        vm_type:
+          type: string
+          enum:
+          - vm
+          - container
+          - ""
+          default: vm
+          example: vm
+    hardware:
+      type: object
+      nullable: true
+      required:
+      - os_type
+      properties:
+        cpu:
+          type: string
+          default: Broadwell
+          example: Broadwell
+        vcpus:
+          oneOf:
+          - type: integer
+          - type: string
+          default: 1
+          example: 4
+        memory:
+          oneOf:
+          - type: integer
+          - type: string
+          default: 1024
+          example: 8192
+        os_type:
+          type: string
+          default: linux
+          example: windows
+    network:
+      type: object
+      nullable: true
+      required:
+      - interfaces
+      properties:
+        interfaces:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            properties:
+              name:
+                type: string
+                example: eth0
+              proto:
+                type: string
+                enum:
+                - static
+                - dhcp
+                - manual
+                - ""
+                default: dhcp
+                example: static
+              address:
+                type: string
+                format: ipv4
+                example: 192.168.1.100
+              mask:
+                type: integer
+                minimum: 0
+                maximum: 32
+                default: 24
+                example: 24
+              gateway:
+                type: string
+                format: ipv4
+                example: 192.168.1.1
+              vlan:
+                type: string
+                example: EXP-1
 ```
 
 ## Interface Schema
@@ -716,67 +714,76 @@ iface:
   - name
   - vlan
   properties:
-	name:
-	  type: string
-	  example: eth0
-	vlan:
-	  type: string
-	  example: EXP-1
-	autostart:
-	  type: boolean
-	  default: true
-	mac:
-	  type: string
-	  example: 00:11:22:33:44:55
-	mtu:
-	  type: integer
-	  default: 1500
-	  example: 1500
-	bridge:
-	  type: string
-	  default: phenix
-	driver:
-	  type: string
-	  example: e1000
+    name:
+      type: string
+      example: eth0
+    vlan:
+      type: string
+      example: EXP-1
+    autostart:
+      type: boolean
+      default: true
+    mac:
+      type: string
+      example: 00:11:22:33:44:55
+      pattern: '^$|^([0-9a-fA-F]{2}[:-]){5}([0-9a-fA-F]){2}$'
+    mtu:
+      type: integer
+      default: 1500
+      example: 1500
+    bridge:
+      type: string
+      default: phenix
+    driver:
+      type: string
+      example: e1000
+    qinq:
+      type: boolean
+      default: false
+
 iface_address:
   type: object
   required:
   - address
   - mask
   properties:
-	address:
-	  type: string
-	  format: ipv4
-	  example: 192.168.1.100
-	mask:
-	  type: integer
-	  minimum: 0
-	  maximum: 32
-	  default: 24
-	  example: 24
-	gateway:
-	  type: string
-	  format: ipv4
-	  example: 192.168.1.1
-	dns:
-	  nullable: true
-	  oneOf:
-	  - type: string
-	  - type: array
-		items:
-		  type: string
-	  example:
-	  - 192.168.1.1
-	  - 192.168.1.2
+    address:
+      type: string
+      format: ipv4
+      example: 192.168.1.100
+    mask:
+      type: integer
+      minimum: 0
+      maximum: 32
+      default: 24
+      example: 24
+    gateway:
+      type: string
+      format: ipv4
+      example: 192.168.1.1
+    dns:
+      nullable: true
+      oneOf:
+      - type: string
+      - type: array
+        items:
+          type: string
+      example:
+      - 192.168.1.1
+      - 192.168.1.2
+
 iface_rulesets:
   type: object
   properties:
-	ruleset_out:
-	  type: string
-	  example: OutToInet
-	ruleset_in:
-	  type: string
-	  example: InFromInet
+    ruleset_out:
+      type: string
+      example: OutToInet
+      pattern: '^[\w-]*$'
+    ruleset_in:
+      type: string
+      example: InFromInet
+      pattern: '^[\w-]*$'
+
 static_iface:
   allOf:
   - $ref: '#/components/schemas/iface'
@@ -786,19 +793,20 @@ static_iface:
   - type
   - proto
   properties:
-	type:
-	  type: string
-	  enum:
-	  - ethernet
-	  default: ethernet
-	  example: ethernet
-	proto:
-	  type: string
-	  enum:
-	  - static
-	  - ospf
-	  default: static
-	  example: static
+    type:
+      type: string
+      enum:
+      - ethernet
+      default: ethernet
+      example: ethernet
+    proto:
+      type: string
+      enum:
+      - static
+      - ospf
+      default: static
+      example: static
+
 dhcp_iface:
   allOf:
   - $ref: '#/components/schemas/iface'
@@ -807,19 +815,20 @@ dhcp_iface:
   - type
   - proto
   properties:
-	type:
-	  type: string
-	  enum:
-	  - ethernet
-	  default: ethernet
-	  example: ethernet
-	proto:
-	  type: string
-	  enum:
-	  - dhcp
-	  - manual
-	  default: dhcp
-	  example: dhcp
+    type:
+      type: string
+      enum:
+      - ethernet
+      default: ethernet
+      example: ethernet
+    proto:
+      type: string
+      enum:
+      - dhcp
+      - manual
+      default: dhcp
+      example: dhcp
+
 serial_iface:
   allOf:
   - $ref: '#/components/schemas/iface'
@@ -832,47 +841,47 @@ serial_iface:
   - baud_rate
   - device
   properties:
-	type:
-	  type: string
-	  enum:
-	  - serial
-	  default: serial
-	  example: serial
-	proto:
-	  type: string
-	  enum:
-	  - static
-	  default: static
-	  example: static
-	udp_port:
-	  type: integer
-	  minimum: 0
-	  maximum: 65535
-	  default: 8989
-	  example: 8989
-	baud_rate:
-	  type: integer
-	  enum:
-	  - 110
-	  - 300
-	  - 600
-	  - 1200
-	  - 2400
-	  - 4800
-	  - 9600
-	  - 14400
-	  - 19200
-	  - 38400
-	  - 57600
-	  - 115200
-	  - 128000
-	  - 256000
-	  default: 9600
-	  example: 9600
-	device:
-	  type: string
-	  default: /dev/ttyS0
-	  example: /dev/ttyS0
+    type:
+      type: string
+      enum:
+      - serial
+      default: serial
+      example: serial
+    proto:
+      type: string
+      enum:
+      - static
+      default: static
+      example: static
+    udp_port:
+      type: integer
+      minimum: 0
+      maximum: 65535
+      default: 8989
+      example: 8989
+    baud_rate:
+      type: integer
+      enum:
+      - 110
+      - 300
+      - 600
+      - 1200
+      - 2400
+      - 4800
+      - 9600
+      - 14400
+      - 19200
+      - 38400
+      - 57600
+      - 115200
+      - 128000
+      - 256000
+      default: 9600
+      example: 9600
+    device:
+      type: string
+      default: /dev/ttyS0
+      example: /dev/ttyS0
 ```
 
 ## Complete Schema


### PR DESCRIPTION
## Description
Refreshed `docs/schema.md` OpenAPI schemas. Fixed tabs being used for indentation (why...?), added missing `iface` fields (`qinq`, `mac` pattern) and `iface_rulesets` patterns, and removed stale `v0`-era `title` fields. 

## Related Issue
N/A

## Type of Change
- [ ] Bugfix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-docs/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Verified with `mkdocs build --strict` (no warnings) and confirmed all existing cross-reference anchors from `apps.md`/`configuration.md` still resolve.
