### PR TITLE
docs(api): add API/Integrations section with Swagger docs reference

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,71 @@
+# API
+
+The phēnix web UI is built entirely on top of a REST API served by the phēnix
+daemon. That same API is available for external tooling and automation, such
+as CI/CD pipelines (see [Git Workflow](git-workflow.md)) or custom scripts.
+
+## Interactive API Docs (Swagger/OpenAPI)
+
+Browsable, interactive API documentation is generated from the project's
+[OpenAPI](https://www.openapis.org/) (Swagger) specification, and is
+available in two places:
+
+* **On this documentation site**: [swagger.html](/swagger.html) (linked from
+  the gear icon in the footer) is a static snapshot of the API docs, rendered
+  from the `openapi.yml` spec at the time the docs were published.
+* **On a running phēnix server**: every phēnix instance also hosts its own
+  copy of the same interactive API docs at the `/docs/` path:
+
+    ```
+    http://<phenix-host>:<port>/docs/
+    ```
+
+    For a default local installation, this would be:
+
+    ```
+    http://localhost:3000/docs/
+    ```
+
+    !!! note
+        `<port>` defaults to `3000` and comes from the `ui.listen-endpoint`
+        setting. See [Settings](settings.md) for details on configuring this.
+
+    Because it's built into the phēnix binary/image itself, `/docs/` on a
+    running server is always in sync with the version of phēnix you're
+    running, whereas [swagger.html](/swagger.html) reflects the spec as of
+    the latest docs release.
+
+The API docs are organized by tag (`Configs`, `Experiments`, `Virtual
+Machines`, `Hosts`, `Applications`, `Topologies`, `Disks`, `Users`, etc.) and
+document every available endpoint, including request parameters and response
+schemas.
+
+!!! info
+    The underlying OpenAPI spec is maintained at
+    [`src/go/web/public/docs/openapi.yml`](https://github.com/sandialabs/sceptre-phenix/blob/main/src/go/web/public/docs/openapi.yml)
+    in the [sceptre-phenix](https://github.com/sandialabs/sceptre-phenix)
+    repository, and is rendered to static HTML with
+    [Redoc](https://github.com/Redocly/redoc) as part of the phēnix build.
+
+## Authentication
+
+If UI/API authentication is enabled (see
+[User Authn/Authz](user-administration.md)), API requests must include an
+auth token generated from the `Users` tab in the web UI, passed as the
+`X-phenix-auth-token` header:
+
+```
+X-phenix-auth-token: ******
+```
+
+See [Generating User Authentication Tokens](user-administration.md#generating-user-authentication-tokens)
+for details.
+
+## Integrations
+
+The phēnix API can be used to integrate phēnix with external systems. Known
+integrations include:
+
+* [Git Workflow](git-workflow.md) - drive experiment topology/scenario
+  updates from a git-based CI/CD pipeline (e.g. a GitLab runner) reacting to
+  push events.

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,3 +95,4 @@ docker exec -it phenix phenix <command>
 * [**Experiments**](experiments.md): Manage the lifecycle of your experiments.
 * [**Apps**](apps.md): Extend functionality with Apps.
 * [**Logging**](logging.md): Learn about the logging facilities in phēnix and how to increase verbosity
+* [**API**](api.md): Explore the interactive Swagger/OpenAPI docs served by phēnix and integrate with the API.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,7 +77,6 @@ nav:
     - Files: configuration.md
     - Settings: settings.md
     - Logging: logging.md
-    - Git Workflow: git-workflow.md
   - Experiments:
     - Overview: experiments.md
     - VMs: vms.md
@@ -90,6 +89,9 @@ nav:
     - State of Health: state-of-health.md
   - Networking:
     - Netflow: netflow.md
+  - Integrations:
+    - API: api.md
+    - Git Workflow: git-workflow.md
   - Administration:
     - Users: user-administration.md
   - Reference:


### PR DESCRIPTION
## Description
- Adds a new API doc page documenting phēnix's Swagger/OpenAPI docs
  - the static snapshot at `/swagger.html` on this site. There was a gear button, which is hidden at bottom of page and I honestly didn't know was there until I went to implement this lol
  - the live interactive docs served at `/docs/` on a running phēnix instance. This wasn't really documented anywhere.
- Add `Integrations` section with the new `API` page and the existing `Git Workflow` page, and links the API page from the home page.

## Related Issue
None.

## Type of Change
- [ ] Bugfix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-docs/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Validated with `mkdocs build --strict` locally (clean build, no warnings/errors).