### PR TITLE
docs: improve external device documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,6 +178,66 @@ configuration schema for an external node in the topology is defined
     This is a quirk of how we internally decide which node schema should be used
     (via `oneOf`).
 
+An external node still requires a `type`, `general.hostname`, and (if you want
+it to show up connected to anything in the topology graph) a `network`
+section, just like a regular node. However, the `external_node` schema is
+intentionally simpler than the schema used for minimega-deployed nodes:
+
+- there is no `drives` key (external nodes have no disk image to snapshot or
+  inject files into)
+- there is no `injections`, `delay`, `routes`, `ospf`, `rulesets`, `advanced`,
+  or `commands` support, since none of those apply to a device that phenix
+  doesn't deploy or control
+- network interfaces only support the flat set of fields shown in the
+  [`external_node` schema](schema.md#external_node-schema) (`name`, `proto`,
+  `address`, `mask`, `gateway`, `vlan`). There's no `oneOf` between
+  static/dhcp/serial interface types like there is for minimega nodes
+
+```yaml
+- type: HIL
+  external: true
+  general:
+    hostname: plc-01
+    description: Physical PLC on the test bench
+  hardware:
+    os_type: linux
+  network:
+    interfaces:
+    - name: eth0
+      vlan: EXP-1
+      address: 192.168.10.50
+      mask: 24
+      proto: static
+```
+
+#### Special and Edge Cases
+
+- **Not deployed, not monitored by C2.** External nodes are never started in
+  minimega and never run `miniccc`, so they're excluded from the automated
+  [State of Health](state-of-health.md#command-and-control) checks (network
+  config, listening ports, processes, CPU load, etc.) that rely on C2. Their IP
+  address(es) are still gathered from the topology, though, so they can be used
+  as the `src` or `dst` of a
+  [`testCustomReachability`](state-of-health.md#configuration-options) entry to
+  ping-test connectivity to/from the external device.
+- **`skipHosts` doesn't apply.** Since external nodes are already skipped from
+  C2-based monitoring, the SoH `skipHosts` setting has no effect on them.
+- **Interfaces on the `MGMT` or `MIRROR` VLANs are ignored in the graph.** The
+  SoH topology graph builder skips any interface whose VLAN is `MGMT` or
+  `MIRROR` (case-insensitive) when drawing connections, regardless of whether
+  the node is external or a regular VM.
+- **`vlan` can be omitted, but then the node won't be connected to anything.**
+  If an external node's interface doesn't specify a `vlan`, or the interface is
+  left off entirely, the node will still appear in the SoH topology graph as an
+  isolated node with no lines connecting it to anything else.
+- **Getting a line drawn in the graph.** To have phenix draw a line between an
+  external node and other nodes in the SoH topology graph, give the external
+  node a `network.interfaces[].vlan` value that exactly matches the `vlan`
+  value used on the interface(s) of the node(s) you want it connected to (the
+  VLAN name acts as the shared switch/interface node in the graph). It doesn't
+  matter whether the matching nodes are VMs or other external nodes &mdash;
+  any two nodes sharing a VLAN name will be connected in the graph.
+
 ### Example
 
 A contrived, four node example &mdash; three VMs and a router &mdash; is given

--- a/docs/state-of-health.md
+++ b/docs/state-of-health.md
@@ -32,6 +32,8 @@ could be:
 * `Not running` (part of the experiment, but currently paused)
 * `Not booted` (part of the experiment, but marked as Do Not Boot)
 * `Not deployed` (part of the experiment, but flushed from minimega)
+* `External` (an [external node](configuration.md#external-nodes), i.e.
+  hardware in the loop, not deployed by minimega)
 * `Experiment stopped`
 
 ![screenshot](images/graph_legend.png){: width=800 .center}
@@ -42,6 +44,12 @@ It is also possible to filter the graph based on nodes that are either:
 * `Not running`
 * `Not booted`
 * `Not deployed`
+
+!!! warning
+    There is no filter option for `External` nodes. Applying any of the filters
+    above will hide external nodes from the graph, since they don't match any
+    of the filterable statuses. Use `Refresh Network` to clear the filter and
+    see external nodes again.
 
 The `Refresh Network` button will reset the filter, showing all nodes.
 
@@ -73,6 +81,39 @@ given VM, it will be noted in the details modal. The following screenshot is an
 example of no SoH information with the VNC button disabled.
 
 ![screenshot](images/soh_no_details.png){: width=800 .center}
+
+### External Devices
+
+Experiments that include hardware-in-the-loop or other devices not deployed by
+minimega can still represent them in the topology graph by adding them to the
+topology as [external nodes](configuration.md#external-nodes) (`external:
+true`). External nodes show up in the graph with the `External` status color
+(see the legend above) and, when hovered, still show which OS type/icon was
+configured for them.
+
+Because external nodes don't run `miniccc`, they're excluded from the
+automated command-and-control-based checks described in [Command and
+Control](#command-and-control) (network config, reachability, listening ports,
+processes, CPU load). Clicking on an external node's details modal will
+therefore always report no SoH information available, and the VNC button will
+be disabled since phenix has no console access to it.
+
+External nodes can still participate in reachability testing indirectly: their
+IP address(es) are read from the topology configuration, so they can be used as
+the `src` or `dst` in a
+[`testCustomReachability`](#configuration-options) entry to verify connectivity
+to/from the device from another VM in the experiment.
+
+!!! tip "Getting a line to draw to an external device"
+    The topology graph only draws a line between two nodes when they share a
+    common VLAN name on one of their network interfaces (the VLAN name becomes
+    the shared switch node in the graph). To connect an external node to the
+    rest of the topology in the graph, give it a `network.interfaces[].vlan`
+    value that matches the VLAN used by the node(s) you want it connected to.
+    Interfaces on the `MGMT` or `MIRROR` VLANs are always ignored when drawing
+    these lines (for both external and internal nodes), and an external node
+    with no `vlan` set on its interface(s) will appear in the graph as an
+    isolated node with no connecting lines.
 
 ### Network Volume
 


### PR DESCRIPTION
## Description

Improves documentation of external devices in a topology and how they're represented in the State of Health (SoH) UI, including edge cases and how to get the topology graph to draw a connecting line to an external node (matching `vlan` names).

## Related Issue
N/A

## Type of Change
- [ ] Bugfix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-docs/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Verified with `mkdocs build --strict` (no warnings/errors).