### PR TITLE
docs: document default app opt-out

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -18,6 +18,27 @@ their `running` stage only when manually triggered by the user.
 | startup | configures minimega startup injections based on OS type                                      |
 | vrouter | customizes Vyatta/VyOS and minirouter routers, including setting interfaces, ACL rules, etc. |
 
+### Disable Default Apps for a VM
+
+To keep a VM managed by `phenix` and minimega without applying the built-in
+default apps, set the `phenix/default-apps` node annotation to `false` in the
+topology:
+
+```yaml title="disable default apps for one VM"
+spec:
+  nodes:
+    - annotations:
+        phenix/default-apps: false
+      general:
+        hostname: custom-vm
+      # remaining node configuration omitted
+```
+
+This skips the `ntp`, `serial`, `startup`, and `vrouter` apps for that node
+during every lifecycle stage. User apps configured in a scenario are
+unaffected. Omit the annotation, or set it to `true`, to retain the default
+behavior.
+
 ### ntp App
 
 The `ntp` app configures experiment VMs to use a NTP server in the experiment.


### PR DESCRIPTION
# docs: document default app opt-out

## Description
Describe the per-node `phenix/default-apps` annotation and its effect on built-in apps.

## Related Issue
PR: https://github.com/sandialabs/sceptre-phenix/pull/348
Issue: https://github.com/sandialabs/sceptre-phenix/issues/156

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-docs/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A
